### PR TITLE
Add extra_files and hipify_extra_files_only to json config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ python hipify_cli.py --config-json hipify_config.json
 hipify_config.json
 ```json
 {
-    "project_directory": <relative path of project_directory to config_json>,   
-    "output_directory" : <relative path of output_directory to config_json>,
-    "header_include_dirs": [<rel path to proj_dir of directories where headers are present>],    
-    "includes":[<rel path to proj_dir of directories to be hipified> ],    
+    "project_directory": <absolute path of project_directory to config_json>,
+    "output_directory" : <absolute path of output_directory to config_json>,
+    "header_include_dirs": [<absolute path to proj_dir of directories where headers are present>],
+    "includes": [<absolute path to proj_dir of directories to be hipified>],
+    "ignores": [<absolute path to proj_dir of directories to explicitly not hipify>],
+    "extra_files": [<absolute or relative paths of extra files to be hipified>],
+    "hipify_extra_files_only": <true or false, whether to only hipify extra files>
 }
 ```
 ### hipify.hipify_python

--- a/hipify_cli.py
+++ b/hipify_cli.py
@@ -88,6 +88,14 @@ def main():
                     ignores = json_args['ignores']
                 else:
                     ignores = []
+                if(json_args.get('extra_files') is not None):
+                    extra_files = json_args['extra_files']
+                else:
+                    extra_files = []
+                if(json_args.get('hipify_extra_files_only') is not None):
+                    hipify_extra_files_only = json_args['hipify_extra_files_only']
+                else:
+                    hipify_extra_files_only = False
         else:
             raise ValueError('config json file specified should be a valid file path')
     else:
@@ -112,7 +120,9 @@ def main():
         ignores=ignores,
         header_include_dirs=args.header_include_dirs if type(args.header_include_dirs) is list \
             else args.header_include_dirs.strip("[]").split(";"),
+        extra_files=extra_files,
         is_pytorch_extension=True,
+        hipify_extra_files_only=hipify_extra_files_only,
         show_detailed=True)
 
     if dump_dict_file:


### PR DESCRIPTION
Add the `extra_files` and `hipify_extra_files_only` options to the json config. Addresses [#1706](https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1706).

Also updates the README to include all the supported options in the json config.

Note: the previous README had incorrectly stated that relative paths should be passed to hipify. I fixed this as well.