### PR TITLE
Fix reference before assignment exception when config_json is not set

### DIFF
--- a/hipify_cli.py
+++ b/hipify_cli.py
@@ -110,6 +110,8 @@ def main():
         includes=args.includes
         ignores=args.ignores
         header_include_dirs=args.header_include_dirs
+        extra_files = []
+        hipify_extra_files_only = False
     dump_dict_file = args.dump_dict_file
     print("project_directory :",project_directory , " output_directory: ", output_directory, " includes: ", includes, " ignores: ", ignores, " header_include_dirs: ", header_include_dirs)
 


### PR DESCRIPTION
Sets defaults for extra_files and hipify_extra_files_only when config_json is not set to prevent reference before assignment exception.