### PR TITLE
Use absolute paths for all file names to hipify.

### DIFF
--- a/hipify/hipify_python.py
+++ b/hipify/hipify_python.py
@@ -1043,6 +1043,8 @@ def hipify(
     # Preprocessing statistics.
     stats: Dict[str, List] = {"unsupported_calls": [], "kernel_launches": []}
 
+    all_files = [ os.path.abspath(filepath) for filepath in all_files ]
+
     for filepath in (all_files if not hipify_extra_files_only else extra_files):
         preprocess_file_and_save_result(output_directory, filepath, all_files, header_include_dirs,
                                         stats, hip_clang_launch, is_pytorch_extension, clean_ctx, show_progress)

--- a/tools/replace_cuda_with_hip_files.py
+++ b/tools/replace_cuda_with_hip_files.py
@@ -36,6 +36,7 @@ def main():
     with open(args.io_file) as inp_file:
         for line in inp_file:
             line = line.strip()
+            line = os.path.abspath(line)
             if line in hipified_result:
                 out_list.append(hipified_result[line]['hipified_path'])
             else:


### PR DESCRIPTION
This fixes issues where some files with names in relative paths were not handled correctly.