### PR TITLE
Add default value for dump-dict-file

### DIFF
--- a/hipify_cli.py
+++ b/hipify_cli.py
@@ -52,6 +52,7 @@ def main():
 
     parser.add_argument(
         '--dump-dict-file',
+        default='hipify_output_dict_dump.txt',
         type=str,
         help="The file to Store the return dict output after hipification",
         required=False)


### PR DESCRIPTION
dump_dict_file is defined as optional argument, but the script raises error if its not defined.
https://github.com/ROCmSoftwarePlatform/hipify_torch/blob/master/hipify_cli.py#L134

This PR adds a default value for dump_dict_file to avoid error when user doesn't define it. 

Other option would be to make dump_dict_file a required argument.

CC: @AdrianAbeyta  @jithunnair-amd 