### PR TITLE
[hipify] Package hipify module and created initial unit test framework. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+from distutils.core import setup
+from setuptools import setup, Extension, distutils, Command, find_packages
+import setuptools.command.install
+import distutils.command.build
+import distutils.command.clean
+import os
+import shutil
+
+## extending the install command functionality.
+class install(setuptools.command.install.install):
+    def run(self):
+        print ("INFO: Installing hipify_torch")
+        setuptools.command.install.install.run(self)
+        print ("OK: Successfully installed hipify_torch")
+
+## extending the clean command functionality.
+class clean(distutils.command.clean.clean):
+    def run(self):
+        print ("INFO: cleaning hipify_torch")
+        cwd = os.getcwd()
+        build_dir = os.path.join(cwd, "build")
+        egg_dir = os.path.join(cwd, "hipify_torch.egg-info")
+        if os.path.isdir(build_dir):
+            shutil.rmtree(build_dir)
+            shutil.rmtree(egg_dir)
+            print("OK: Deleted the build directory.")
+
+        distutils.command.clean.clean.run(self)
+
+cmd_class = {
+    "clean"   : clean,
+    "install" : install,
+    }
+
+setup(
+    name='hipify_torch',
+    version='0.1',
+    cmdclass=cmd_class,
+    packages=['hipify',],
+    long_description=open('README.md').read(),
+    )

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -1,0 +1,12 @@
+import unittest
+
+class TestHipifyInstallation(unittest.TestCase):
+    def test_hipify_torch_installation(self):
+        try:
+            from hipify import hipify_python
+        except ImportError:
+            print ("ERROR: please install hipify_torch using setup.py install")
+            raise ImportError('Install hipify_torch module')
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR contains a setup file to install hipify and also created test folder which contains a simple test framework for unit testing. 
Usage
```
python setup.py install 
```

After installation, use the hipify module as below:
```
from hipify import hipify_python
```