### PR TITLE
Revert "Replace hipProfilerStart/Stop with roctracer functions"

### DIFF
--- a/hipify_torch/cuda_to_hip_mappings.py
+++ b/hipify_torch/cuda_to_hip_mappings.py
@@ -5236,8 +5236,8 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             "cudaProfilerInitialize",
             ("hipProfilerInitialize", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED),
         ),
-        ("cudaProfilerStart", ("roctracer_start", CONV_OTHER, API_RUNTIME)),
-        ("cudaProfilerStop", ("roctracer_stop", CONV_OTHER, API_RUNTIME)),
+        ("cudaProfilerStart", ("hipProfilerStart", CONV_OTHER, API_RUNTIME)),
+        ("cudaProfilerStop", ("hipProfilerStop", CONV_OTHER, API_RUNTIME)),
         (
             "cudaKeyValuePair",
             ("hipKeyValuePair", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED),


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/hipify_torch#60
because `hipProfilerStart` returns `hipError_t` but `roctracer_start` returns void.

cc @pnunna93 @lcskrishna 